### PR TITLE
Include port number if present

### DIFF
--- a/lib/gollum.ex
+++ b/lib/gollum.ex
@@ -47,7 +47,12 @@ defmodule Gollum do
     name = opts[:name] || Gollum.Cache
 
     uri = URI.parse(url)
-    host = "#{uri.scheme}://#{uri.host}"
+    port = case {uri.port, uri.scheme} do
+      {80, "http"} -> ""
+      {443, "https"} -> ""
+      {port, _} -> ":#{port}"
+    end
+    host = "#{uri.scheme}://#{uri.host}#{port}"
     path = uri.path || "/"
 
     case Cache.fetch(host, name: name) do


### PR DESCRIPTION
Port numbers were ignored when creating the host url to check. This has caused some issues in my usage of Gollum.

This change explicitly includes the port number provided as long as it's not the standard port for the protocol used. I.e.
- http://domain:40 will produce the equivalent host
- http://domain:80 will produce http://domain